### PR TITLE
Use Ninja-Build instead of Unix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export TICLANG_ARMCOMPILER
 export GCC_ARMCOMPILER
 export IAR_ARMCOMPILER
 
-GENERATOR="Unix Makefiles"
+GENERATOR="Ninja"
 
 build: build-ticlang build-gcc build-iar build-sdk-specific
 


### PR DESCRIPTION
Ninja 
- Uses [Apache-2.0 License](https://github.com/ninja-build/ninja?tab=Apache-2.0-1-ov-file#readme)
- Builds faster and is a simple substitution for `"Unix Makefile"`
- Tested on [Ninja 1.12.0](https://github.com/ninja-build/ninja)

Also available as installable package (e.g. `ninja-build`) for most linux distributions
