### PR TITLE
Fix CC2652RB and stack settings overriding board settings

### DIFF
--- a/source/ti/common/.meta/lprf_ccfg_settings.js
+++ b/source/ti/common/.meta/lprf_ccfg_settings.js
@@ -263,8 +263,8 @@ for(stack of Common.stacks)
         // Verify that the stack has ccfgSettings to provide before setting them
         if((stackCommon !== undefined) && (stackCommon.ccfgSettings))
         {
-            ccfgSettings = Object.assign(ccfgSettings,
-                stackCommon.ccfgSettings);
+            // Board specific settings have preference over stack common settings 
+            ccfgSettings = Object.assign({}, stackCommon.ccfgSettings, ccfgSettings);
         }
     }
 }

--- a/source/ti/prop_rf/.meta/prop_rf_common.js
+++ b/source/ti/prop_rf/.meta/prop_rf_common.js
@@ -97,7 +97,7 @@ const propRfCCFGSettings = {
         forceVddr: false,
         enableBootloaderBackdoor: false
     },
-    CC2652RB_LAUNCHXL_CCFG_SETTINGS: {
+    LP_CC2652RB_CCFG_SETTINGS: {
         forceVddr: false,
         enableBootloaderBackdoor: false
     },


### PR DESCRIPTION
This PR fixes 2 issues:
- Incorrect CC2652RB board name in `source/ti/prop_rf/.meta/prop_rf_common.js` which causes these settings to be ignored
- The stack common settings overriding the board settings, this causes e.g. the `enableBootloaderBackdoor: true` from `source/ti/common/.meta/lprf_ccfg_settings.js` to be overridden by the `enableBootloaderBackdoor: false` from `source/ti/prop_rf/.meta/prop_rf_common.js` (resulting in a `enableBootloaderBackdoor: false`).