### PR TITLE
Fix open C++ guards.

### DIFF
--- a/source/third_party/mbedtls/ti/port/sha256_alt.h
+++ b/source/third_party/mbedtls/ti/port/sha256_alt.h
@@ -85,6 +85,10 @@ typedef struct
     SHA2_Object object; /*!< Pointer to a driver specific data object */
 } mbedtls_sha256_context;
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MBEDTLS_SHA256_ALT */
 
 #endif /* MBEDTLS_SHA256_ALT_H */

--- a/source/third_party/mbedtls/ti/port/sha512_alt.h
+++ b/source/third_party/mbedtls/ti/port/sha512_alt.h
@@ -86,6 +86,10 @@ typedef struct
     SHA2_Object object; /*!< Pointer to a driver specific data object */
 } mbedtls_sha512_context;
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MBEDTLS_SHA512_ALT */
 
 #endif /* MBEDTLS_SHA512_ALT_H */


### PR DESCRIPTION
This fixes the open C++ guards in the sha256/512 mbedTLS alt implementations.